### PR TITLE
Add signature verification failure test

### DIFF
--- a/backend/testing/test_transaction.py
+++ b/backend/testing/test_transaction.py
@@ -32,3 +32,19 @@ def test_ecdsa_signature(sender, receiver, amount):
     tx.sign(private_key, secp256k1)
 
     assert tx.verify(public_key, secp256k1), "Signature verification failed!"
+
+
+def test_invalid_signature():
+    """Signature verification should fail with the wrong public key."""
+    # Generate first key pair
+    priv1 = random.randint(1, secp256k1.n - 1)
+    pub1 = secp256k1.scalar_multiply(priv1, secp256k1.G)
+
+    # Generate second key pair
+    priv2 = random.randint(1, secp256k1.n - 1)
+    pub2 = secp256k1.scalar_multiply(priv2, secp256k1.G)
+
+    tx = Transaction("Alice", "Bob", 42)
+    tx.sign(priv1, secp256k1)
+
+    assert not tx.verify(pub2, secp256k1), "Verification should fail with a different public key"


### PR DESCRIPTION
## Summary
- add missing newline
- test that signing with one keypair but verifying with another fails

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6840087bd874832099209c55314d8b2e